### PR TITLE
Updated for Tin v2.1

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -68,27 +68,21 @@ I usually just manually copy Tcllib into the `lib` directory of my Tcl installat
 
 ...so I can run Tcl the same way on both platforms.
 
+## Installing Testin with Tin
 
-## Installing Testin with Tin ##
-
-### Linux ###
-
-Linux is different from Windows because of permissions.  I need sudo to install Tcl packages to `/usr/share/tcltk`.
+The following code installs testin on both Linux and Windows
 
 ```
-$ sudo tclsh
-% package require tin
-1.1
+$ tclsh
+% package require tin 2.1
+2.1
 %
-% tin add -auto testin https://github.com/johnpeck/testin install.tcl
-% tin install testin 1.1
-searching in the Tin for testin 1.1 ...
-installing testin 1.1 from https://github.com/johnpeck/testin v1.1 ...
-testin version 1.1 installed successfully
-1.1
+% tin autoadd testin https://github.com/johnpeck/testin install.tcl
+% tin install testin 1.4
+searching in the Tin for testin 1.4 ...
+installing testin 1.4 from https://github.com/johnpeck/testin v1.1 ...
+testin version 1.4 installed successfully
+1.4
 ```
 
-### Windows ###
-
-Windows is the same as Linux, except you can skip the sudo.
 

--- a/install.tcl
+++ b/install.tcl
@@ -1,7 +1,7 @@
 # Hey Emacs, use -*- Tcl -*- mode
 
-package require tin 1.0
+package require tin 2.1
 
-set dir [tin mkdir -force testin 1.3]
+set dir [tin mkdir -force testin 1.4]
 file copy testin.tcl $dir
 file copy pkgIndex.tcl $dir

--- a/makefile
+++ b/makefile
@@ -12,7 +12,7 @@ package_name = testin
 # https://www.tcl-lang.org/man/tcl/TclCmd/package.htm
 #
 # Tin allows two digits: major.minor
-version = 1.3
+version = 1.4
 
 ######################## End of Configuration ########################
 

--- a/pkgIndex.tcl
+++ b/pkgIndex.tcl
@@ -1,4 +1,4 @@
 # Hey Emacs, use -*- Tcl -*- mode
 
 if {![package vsatisfies [package provide Tcl] 8.6]} {return}
-package ifneeded testin 1.3 [list source [file join $dir testin.tcl]]
+package ifneeded testin 1.4 [list source [file join $dir testin.tcl]]

--- a/src/install.tin
+++ b/src/install.tin
@@ -1,6 +1,6 @@
 # Hey Emacs, use -*- Tcl -*- mode
 
-package require tin 1.0
+package require tin 2.1
 
 set dir [tin mkdir -force testin @VERSION@]
 file copy testin.tcl $dir

--- a/testin.tcl
+++ b/testin.tcl
@@ -29,4 +29,4 @@ proc ::testin::intlist {args} {
 }
 
 # Finally, provide the package
-package provide testin 1.3
+package provide testin 1.4


### PR DESCRIPTION
This new version should address issue #1 . Code for testing installation from my fork is as follows:

```tcl
package require tin 2.1
tin autoadd testin https://github.com/ambaker1/testin install.tcl
tin install testin 1.4
```

Instructions are updated in the readme, with your repo url instead of mine. Let me know if it works on Linux